### PR TITLE
Initial implementation of workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@prefecthq/platform

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,25 @@
+---
+name: Static analysis
+
+"on":
+  pull_request: {}
+
+permissions: {}
+
+jobs:
+  pre_commit_checks:
+    name: pre-commit checks
+    runs-on: ubuntu-latest
+    permissions:
+      # required to read from the repo
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Install tool dependencies
+        uses: jdx/mise-action@v2
+
+      - name: Run pre-commit
+        run: |
+          pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,4 @@
+[tools]
+pre-commit = '3.8.0'
+shellcheck = '0.10.0'
+yamllint = '1.35.1'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+---
+fail_fast: false
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.28.0
+    hooks:
+      - id: yamllint
+        args:
+          - --strict
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.7.2
+    hooks:
+      - id: shellcheck
+        args: ["--severity=error"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # actions-mise-upgrade
-GitHub workflow to upgrade tools managed by mise
+
+GitHub workflow to upgrade tools managed by [`mise`](https://mise.jdx.dev).
+
+Uses the [`mise upgrade`](https://mise.jdx.dev/cli/upgrade.html) command to
+check for the latest versions of each tool and update the `.mise.toml` with
+the results.
+
+## Inputs
+
+There are currently no inputs to provide to this action.
+
+## Usage
+
+```yaml
+name: Update mise tool versions
+"on":
+  schedule:
+      - cron: 0 15 1 * * # First day of each month at 15:00 UTC
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    permissions:
+      # required to write to the repo
+      contents: write
+      # required to open a pr with changes
+      pull-requests: write
+    steps:
+      - name: upgrade mise tools
+        uses: prefecthq/actions-mise-upgrade@main
+```

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ jobs:
       - name: upgrade mise tools
         uses: prefecthq/actions-mise-upgrade@main
 ```
+
+## References
+
+- https://github.com/jdx/mise/discussions/1823: this issue discusses workflows for plugin updates. Might be worth following along in case there ends up being a more 'official' way to do this.
+- https://github.com/jdx/mise/discussions/4057: this discussion mentions the `mise upgrade --bump` command we're using here, along with some context.
+- https://github.com/jdx/mise/discussions/4241: this discussion suggests adding a changelog to the `self-update` command, which is somewhat related and hopefully will carry over to the `upgrade` command for us to use in pull request descriptions.

--- a/action.yaml
+++ b/action.yaml
@@ -1,72 +1,63 @@
 ---
 name: Update mise tool versions
+author: PrefectHQ
+description: This action will upgrade tools managed by mise and open a PR.
 
-"on":
-  schedule:
-    - cron: 0 15 1 * *  # First of the month @ 3pm UTC
-  workflow_dispatch: {}
+inputs: {}
 
-permissions: {}
+runs:
+  using: composite
+  steps:
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        # This should be 'main' anyway as it will run
+        # on a schedule, but let's be explicit so we can,
+        # for example, run this from pull request branches.
+        ref: 'main'
 
-jobs:
-  updatecli_major:
-    runs-on: ubuntu-latest
-    permissions:
-      # required to write to the repo
-      contents: write
-      # required to open a pr with changes
-      pull-requests: write
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-        with:
-          # This should be 'main' anyway as it will run
-          # on a schedule, but let's be explicit so we can,
-          # for example, run this from pull request branches.
-          ref: 'main'
+    - name: install mise
+      uses: jdx/mise-action@v2
 
-      - name: install mise
-        uses: jdx/mise-action@v2
+    - name: upgrade tools in mise
+      run: mise upgrade --bump
 
-      - name: upgrade tools in mise
-        run: mise upgrade --bump
+    - name: determine if there are changes
+      run: |
+        if [[ $(git diff --name-only | wc -l) -eq 0 ]]; then
+          echo "No changes detected, exiting"
+          echo "CHANGES=false" >> $GITHUB_ENV
+          exit 0
+        else
+          echo "CHANGES=true" >> $GITHUB_ENV
+        fi
 
-      - name: determine if there are changes
-        run: |
-          if [[ $(git diff --name-only | wc -l) -eq 0 ]]; then
-            echo "No changes detected, exiting"
-            echo "CHANGES=false" >> $GITHUB_ENV
-            exit 0
-          else
-            echo "CHANGES=true" >> $GITHUB_ENV
-          fi
+    - name: configure git
+      if: env.CHANGES == 'true'
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: configure git
-        if: env.CHANGES == 'true'
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+    - name: determine branch name
+      if: env.CHANGES == 'true'
+      run: |
+        echo "BRANCH_NAME=mise-updates-$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      - name: determine branch name
-        if: env.CHANGES == 'true'
-        run: |
-          echo "BRANCH_NAME=mise-updates-$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+    - name: commit and push changes
+      if: env.CHANGES == 'true'
+      run: |
+        git checkout -b $BRANCH_NAME
+        git add .mise.toml
+        git commit -m 'Update mise tool versions'
+        git push --set-upstream origin $BRANCH_NAME
 
-      - name: commit and push changes
-        if: env.CHANGES == 'true'
-        run: |
-          git checkout -b $BRANCH_NAME
-          git add .mise.toml
-          git commit -m 'Update mise tool versions'
-          git push --set-upstream origin $BRANCH_NAME
-
-      - name: create pull request
-        if: env.CHANGES == 'true'
-        run: |
-          gh pr create \
-            --base main \
-            --title "Update mise tool versions" \
-            --label automated-dependency-updates
-        env:
-          # Required for the `gh` CLI
-          GH_TOKEN: ${{ github.token }}
+    - name: create pull request
+      if: env.CHANGES == 'true'
+      run: |
+        gh pr create \
+          --base main \
+          --title "Update mise tool versions" \
+          --label automated-dependency-updates
+      env:
+        # Required for the `gh` CLI
+        GH_TOKEN: ${{ github.token }}

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,72 @@
+---
+name: Update mise tool versions
+
+"on":
+  schedule:
+    - cron: 0 15 1 * *  # First of the month @ 3pm UTC
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  updatecli_major:
+    runs-on: ubuntu-latest
+    permissions:
+      # required to write to the repo
+      contents: write
+      # required to open a pr with changes
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          # This should be 'main' anyway as it will run
+          # on a schedule, but let's be explicit so we can,
+          # for example, run this from pull request branches.
+          ref: 'main'
+
+      - name: install mise
+        uses: jdx/mise-action@v2
+
+      - name: upgrade tools in mise
+        run: mise upgrade --bump
+
+      - name: determine if there are changes
+        run: |
+          if [[ $(git diff --name-only | wc -l) -eq 0 ]]; then
+            echo "No changes detected, exiting"
+            echo "CHANGES=false" >> $GITHUB_ENV
+            exit 0
+          else
+            echo "CHANGES=true" >> $GITHUB_ENV
+          fi
+
+      - name: configure git
+        if: env.CHANGES == 'true'
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: determine branch name
+        if: env.CHANGES == 'true'
+        run: |
+          echo "BRANCH_NAME=mise-updates-$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: commit and push changes
+        if: env.CHANGES == 'true'
+        run: |
+          git checkout -b $BRANCH_NAME
+          git add .mise.toml
+          git commit -m 'Update mise tool versions'
+          git push --set-upstream origin $BRANCH_NAME
+
+      - name: create pull request
+        if: env.CHANGES == 'true'
+        run: |
+          gh pr create \
+            --base main \
+            --title "Update mise tool versions" \
+            --label automated-dependency-updates
+        env:
+          # Required for the `gh` CLI
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Adds a workflow to upgrade tools defined in `mise`.

Modeled after https://github.com/PrefectHQ/actions-updatecli-apply.

Related to https://linear.app/prefect/issue/PLA-961/automate-updating-dependencies-defined-in-mise

## Testing

As far as I can tell, we can't really test this workflow until a caller references it (with that change merged to `main`). So I'd propose we merge this and something like https://github.com/PrefectHQ/prefect-helm/pull/435, test it out, and then I can tweak as needed.

As for manually testing the core change, here's the output in `prefect-helm` from running the `mise upgrade --bump` command:

```diff
diff --git a/.mise.toml b/.mise.toml
index 4864c64..40bdc2d 100644
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,9 @@
 [tools]
-actionlint = '1.7.1'
-github-cli = '2.52.0'
-helm = '3.15'
-helm-ct = '3.11.0'
-helm-docs = '1.13.1'
-pre-commit = '3.8.0'
+actionlint = "1.7.7"
+github-cli = "2.65.0"
+helm = "3.17"
+helm-ct = "3.12.0"
+helm-docs = "1.14.2"
+pre-commit = "4.1.0"
 shellcheck = '0.10.0'
 yamllint = '1.35.1'
```