### PR TITLE
fix(action): specify shell for run steps

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,7 @@ runs:
 
     - name: upgrade tools in mise
       run: mise upgrade --bump
+      shell: bash
 
     - name: determine if there are changes
       run: |
@@ -31,17 +32,20 @@ runs:
         else
           echo "CHANGES=true" >> $GITHUB_ENV
         fi
+      shell: bash
 
     - name: configure git
       if: env.CHANGES == 'true'
       run: |
         git config user.name "$GITHUB_ACTOR"
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      shell: bash
 
     - name: determine branch name
       if: env.CHANGES == 'true'
       run: |
         echo "BRANCH_NAME=mise-updates-$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      shell: bash
 
     - name: commit and push changes
       if: env.CHANGES == 'true'
@@ -50,6 +54,7 @@ runs:
         git add .mise.toml
         git commit -m 'Update mise tool versions'
         git push --set-upstream origin $BRANCH_NAME
+      shell: bash
 
     - name: create pull request
       if: env.CHANGES == 'true'
@@ -61,3 +66,4 @@ runs:
       env:
         # Required for the `gh` CLI
         GH_TOKEN: ${{ github.token }}
+      shell: bash


### PR DESCRIPTION
Looks like 'shell' is a required field for 'run' steps.

Should address failures: https://github.com/PrefectHQ/prefect-helm/actions/runs/13076732150/job/36490899339

Related to https://linear.app/prefect/issue/PLA-961/automate-updating-dependencies-defined-in-mise